### PR TITLE
✨ Refactor Storybook stories to display full function source in "Show code"

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -6,8 +6,16 @@ import 'unfonts.css';
 
 import { withThemeByClassName } from "@storybook/addon-themes";
 
+
 const preview: Preview = {
   parameters: {
+    // 📘 Enable dynamic source extraction for all stories:
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+
     backgrounds: {
       default: 'white',
       values: [

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -32,5 +32,4 @@ export function Default() {
   return <Calendar mode="single" selected={date} onSelect={setDate} className="rounded-md border border-border" />;
 }
 
-// optional: give it a nicer name in the UI
 Default.storyName = 'Default';

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { Calendar } from '@/elements/calendar';
 
-const meta: Meta<typeof Calendar> = {
+const meta = {
   title: 'Elements/Calendar',
   component: Calendar,
   tags: ['autodocs'],
@@ -20,7 +20,8 @@ A reusable Calendar component.
       },
     },
   },
-};
+} satisfies Meta<typeof Calendar>;
+
 export default meta;
 
 export function Default() {

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -26,7 +26,6 @@ A reusable Calendar component.
 };
 export default meta;
 
-// instead of `export const Default: Story = {...}`, do:
 export function Default() {
   const [date, setDate] = useState<Date | undefined>(new Date());
 

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -18,9 +18,6 @@ A reusable Calendar component.
 - react-day-picker (also requires import of 'react-day-picker/style.css')
         `,
       },
-      source: {
-        type: 'dynamic', // extract whole function
-      },
     },
   },
 };

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable react-hooks/rules-of-hooks */
+// Calendar.stories.tsx
+import type { Meta } from "@storybook/react-vite";
+import { useState } from "react";
 
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { Calendar } from "@/elements/calendar";
 
-import { Calendar } from '@/elements/calendar';
-
-const meta = {
-  title: 'Elements/Calendar',
-  tags: ['autodocs'],
+const meta: Meta<typeof Calendar> = {
+  title: "Elements/Calendar",
   component: Calendar,
+  tags: ["autodocs"],
   parameters: {
     docs: {
       description: {
@@ -20,18 +19,27 @@ A reusable Calendar component.
 - react-day-picker (also requires import of 'react-day-picker/style.css')
         `,
       },
+      source: {
+        type: "dynamic", // extract whole function
+      },
     },
   },
-} satisfies Meta<typeof Calendar>;
-
+};
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+// instead of `export const Default: Story = {...}`, do:
+export function Default() {
+  const [date, setDate] = useState<Date | undefined>(new Date());
 
-export const Default: Story = {
-  render: () => {
-    const [date, setDate] = useState<Date | undefined>(new Date());
+  return (
+    <Calendar
+      mode="single"
+      selected={date}
+      onSelect={setDate}
+      className="rounded-md border border-border"
+    />
+  );
+}
 
-    return <Calendar mode="single" selected={date} onSelect={setDate} className="rounded-md border border-border" />;
-  },
-};
+// optional: give it a nicer name in the UI
+Default.storyName = "Default";

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -1,13 +1,13 @@
 // Calendar.stories.tsx
-import type { Meta } from "@storybook/react-vite";
-import { useState } from "react";
+import type { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
 
-import { Calendar } from "@/elements/calendar";
+import { Calendar } from '@/elements/calendar';
 
 const meta: Meta<typeof Calendar> = {
-  title: "Elements/Calendar",
+  title: 'Elements/Calendar',
   component: Calendar,
-  tags: ["autodocs"],
+  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {
@@ -20,7 +20,7 @@ A reusable Calendar component.
         `,
       },
       source: {
-        type: "dynamic", // extract whole function
+        type: 'dynamic', // extract whole function
       },
     },
   },
@@ -31,15 +31,8 @@ export default meta;
 export function Default() {
   const [date, setDate] = useState<Date | undefined>(new Date());
 
-  return (
-    <Calendar
-      mode="single"
-      selected={date}
-      onSelect={setDate}
-      className="rounded-md border border-border"
-    />
-  );
+  return <Calendar mode="single" selected={date} onSelect={setDate} className="rounded-md border border-border" />;
 }
 
 // optional: give it a nicer name in the UI
-Default.storyName = "Default";
+Default.storyName = 'Default';

--- a/src/elements/calendar.stories.tsx
+++ b/src/elements/calendar.stories.tsx
@@ -1,4 +1,3 @@
-// Calendar.stories.tsx
 import type { Meta } from '@storybook/react-vite';
 import { useState } from 'react';
 

--- a/src/elements/card.stories.tsx
+++ b/src/elements/card.stories.tsx
@@ -1,13 +1,21 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta } from "@storybook/react-vite";
 
-import { Button } from '@/elements/button';
-import { Input } from '@/elements/input';
-import { Label } from '@/elements/label';
-import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/elements/card';
+import { Button } from "@/elements/button";
+import { Input } from "@/elements/input";
+import { Label } from "@/elements/label";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/elements/card";
 
 const meta = {
-  title: 'Elements/Card',
-  tags: ['autodocs'],
+  title: "Elements/Card",
+  tags: ["autodocs"],
   component: Card,
   parameters: {
     docs: {
@@ -22,14 +30,15 @@ A reusable Card component.
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Demo = {
-  render: () => (
+// Export as a named function so Docs “dynamic” source shows the full body
+export function Demo() {
+  return (
     <Card className="w-full max-w-sm">
       <CardHeader>
         <CardTitle>Login to your account</CardTitle>
-        <CardDescription>Enter your email below to login to your account</CardDescription>
+        <CardDescription>
+          Enter your email below to login to your account
+        </CardDescription>
         <CardAction>
           <Button variant="link">Sign Up</Button>
         </CardAction>
@@ -39,7 +48,12 @@ export const Demo = {
           <div className="flex flex-col gap-6">
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" placeholder="m@example.com" required />
+              <Input
+                id="email"
+                type="email"
+                placeholder="m@example.com"
+                required
+              />
             </div>
             <div className="grid gap-2">
               <div className="flex items-center">
@@ -65,5 +79,5 @@ export const Demo = {
         </Button>
       </CardFooter>
     </Card>
-  ),
-} satisfies Story;
+  );
+}

--- a/src/elements/card.stories.tsx
+++ b/src/elements/card.stories.tsx
@@ -1,21 +1,13 @@
-import type { Meta } from "@storybook/react-vite";
+import type { Meta } from '@storybook/react-vite';
 
-import { Button } from "@/elements/button";
-import { Input } from "@/elements/input";
-import { Label } from "@/elements/label";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/elements/card";
+import { Button } from '@/elements/button';
+import { Input } from '@/elements/input';
+import { Label } from '@/elements/label';
+import { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/elements/card';
 
 const meta = {
-  title: "Elements/Card",
-  tags: ["autodocs"],
+  title: 'Elements/Card',
+  tags: ['autodocs'],
   component: Card,
   parameters: {
     docs: {
@@ -36,9 +28,7 @@ export function Demo() {
     <Card className="w-full max-w-sm">
       <CardHeader>
         <CardTitle>Login to your account</CardTitle>
-        <CardDescription>
-          Enter your email below to login to your account
-        </CardDescription>
+        <CardDescription>Enter your email below to login to your account</CardDescription>
         <CardAction>
           <Button variant="link">Sign Up</Button>
         </CardAction>
@@ -48,12 +38,7 @@ export function Demo() {
           <div className="flex flex-col gap-6">
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="m@example.com"
-                required
-              />
+              <Input id="email" type="email" placeholder="m@example.com" required />
             </div>
             <div className="grid gap-2">
               <div className="flex items-center">

--- a/src/elements/card.stories.tsx
+++ b/src/elements/card.stories.tsx
@@ -22,7 +22,6 @@ A reusable Card component.
 
 export default meta;
 
-// Export as a named function so Docs “dynamic” source shows the full body
 export function Demo() {
   return (
     <Card className="w-full max-w-sm">

--- a/src/elements/checkbox.stories.tsx
+++ b/src/elements/checkbox.stories.tsx
@@ -1,11 +1,11 @@
-import type { Meta } from "@storybook/react-vite";
+import type { Meta } from '@storybook/react-vite';
 
-import { Checkbox } from "@/elements/checkbox";
-import { Label } from "@/elements/label";
+import { Checkbox } from '@/elements/checkbox';
+import { Label } from '@/elements/label';
 
 const meta = {
-  title: "Elements/Checkbox",
-  tags: ["autodocs"],
+  title: 'Elements/Checkbox',
+  tags: ['autodocs'],
   component: Checkbox,
   parameters: {
     docs: {
@@ -52,12 +52,8 @@ export function Demo() {
           className="data-[state=checked]:border-blue-600 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white dark:data-[state=checked]:border-blue-700 dark:data-[state=checked]:bg-blue-700"
         />
         <div className="grid gap-1.5 font-normal">
-          <p className="text-sm leading-none font-medium">
-            Enable notifications
-          </p>
-          <p className="text-muted-foreground text-sm">
-            You can enable or disable notifications at any time.
-          </p>
+          <p className="text-sm leading-none font-medium">Enable notifications</p>
+          <p className="text-muted-foreground text-sm">You can enable or disable notifications at any time.</p>
         </div>
       </Label>
     </div>

--- a/src/elements/checkbox.stories.tsx
+++ b/src/elements/checkbox.stories.tsx
@@ -1,11 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta } from "@storybook/react-vite";
 
-import { Checkbox } from '@/elements/checkbox';
-import { Label } from '@/elements/label';
+import { Checkbox } from "@/elements/checkbox";
+import { Label } from "@/elements/label";
 
 const meta = {
-  title: 'Elements/Checkbox',
-  tags: ['autodocs'],
+  title: "Elements/Checkbox",
+  tags: ["autodocs"],
   component: Checkbox,
   parameters: {
     docs: {
@@ -24,10 +24,9 @@ A reusable Checkbox component.
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Demo = {
-  render: () => (
+// Named function export so Docs “dynamic” source shows the full body
+export function Demo() {
+  return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center gap-3">
         <Checkbox id="terms" />
@@ -53,10 +52,14 @@ export const Demo = {
           className="data-[state=checked]:border-blue-600 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white dark:data-[state=checked]:border-blue-700 dark:data-[state=checked]:bg-blue-700"
         />
         <div className="grid gap-1.5 font-normal">
-          <p className="text-sm leading-none font-medium">Enable notifications</p>
-          <p className="text-muted-foreground text-sm">You can enable or disable notifications at any time.</p>
+          <p className="text-sm leading-none font-medium">
+            Enable notifications
+          </p>
+          <p className="text-muted-foreground text-sm">
+            You can enable or disable notifications at any time.
+          </p>
         </div>
       </Label>
     </div>
-  ),
-} satisfies Story;
+  );
+}

--- a/src/elements/dropdown-menu.stories.tsx
+++ b/src/elements/dropdown-menu.stories.tsx
@@ -1,8 +1,8 @@
-import type { Meta } from "@storybook/react-vite";
-import type { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
-import { useState } from "react";
+import type { Meta } from '@storybook/react-vite';
+import type { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu';
+import { useState } from 'react';
 
-import { Button } from "@/elements/button";
+import { Button } from '@/elements/button';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -12,13 +12,13 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/elements/dropdown-menu";
+} from '@/elements/dropdown-menu';
 
-type Checked = DropdownMenuCheckboxItemProps["checked"];
+type Checked = DropdownMenuCheckboxItemProps['checked'];
 
 const meta = {
-  title: "Elements/Dropdown Menu",
-  tags: ["autodocs"],
+  title: 'Elements/Dropdown Menu',
+  tags: ['autodocs'],
   component: DropdownMenu,
   parameters: {
     docs: {
@@ -50,23 +50,13 @@ export function Checkboxes() {
       <DropdownMenuContent className="w-56">
         <DropdownMenuLabel>Appearance</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuCheckboxItem
-          checked={showStatusBar}
-          onCheckedChange={setShowStatusBar}
-        >
+        <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
           Status Bar
         </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem
-          checked={showActivityBar}
-          onCheckedChange={setShowActivityBar}
-          disabled
-        >
+        <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
           Activity Bar
         </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem
-          checked={showPanel}
-          onCheckedChange={setShowPanel}
-        >
+        <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
           Panel
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
@@ -75,7 +65,7 @@ export function Checkboxes() {
 }
 
 export function RadioGroup() {
-  const [position, setPosition] = useState("bottom");
+  const [position, setPosition] = useState('bottom');
 
   return (
     <DropdownMenu>

--- a/src/elements/dropdown-menu.stories.tsx
+++ b/src/elements/dropdown-menu.stories.tsx
@@ -1,8 +1,8 @@
-import type { DropdownMenuCheckboxItemProps } from '@radix-ui/react-dropdown-menu';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import type { Meta } from "@storybook/react-vite";
+import type { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
+import { useState } from "react";
 
-import { Button } from '@/elements/button';
+import { Button } from "@/elements/button";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -12,11 +12,13 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/elements/dropdown-menu';
+} from "@/elements/dropdown-menu";
+
+type Checked = DropdownMenuCheckboxItemProps["checked"];
 
 const meta = {
-  title: 'Elements/Dropdown Menu',
-  tags: ['autodocs'],
+  title: "Elements/Dropdown Menu",
+  tags: ["autodocs"],
   component: DropdownMenu,
   parameters: {
     docs: {
@@ -35,11 +37,7 @@ A reusable Dropdown Menu component.
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-type Checked = DropdownMenuCheckboxItemProps['checked'];
-
-const CheckboxesExample = () => {
+export function Checkboxes() {
   const [showStatusBar, setShowStatusBar] = useState<Checked>(true);
   const [showActivityBar, setShowActivityBar] = useState<Checked>(false);
   const [showPanel, setShowPanel] = useState<Checked>(false);
@@ -52,26 +50,32 @@ const CheckboxesExample = () => {
       <DropdownMenuContent className="w-56">
         <DropdownMenuLabel>Appearance</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+        <DropdownMenuCheckboxItem
+          checked={showStatusBar}
+          onCheckedChange={setShowStatusBar}
+        >
           Status Bar
         </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar} disabled>
+        <DropdownMenuCheckboxItem
+          checked={showActivityBar}
+          onCheckedChange={setShowActivityBar}
+          disabled
+        >
           Activity Bar
         </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+        <DropdownMenuCheckboxItem
+          checked={showPanel}
+          onCheckedChange={setShowPanel}
+        >
           Panel
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
-};
+}
 
-export const Checkboxes = {
-  render: () => <CheckboxesExample />,
-} satisfies Story;
-
-const RadioGroupExample = () => {
-  const [position, setPosition] = useState('bottom');
+export function RadioGroup() {
+  const [position, setPosition] = useState("bottom");
 
   return (
     <DropdownMenu>
@@ -89,8 +93,4 @@ const RadioGroupExample = () => {
       </DropdownMenuContent>
     </DropdownMenu>
   );
-};
-
-export const RadioGroup = {
-  render: () => <RadioGroupExample />,
-} satisfies Story;
+}

--- a/src/elements/tabs.stories.tsx
+++ b/src/elements/tabs.stories.tsx
@@ -1,68 +1,22 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta } from "@storybook/react-vite";
 
-import { Button } from '@/elements/button';
-import { Input } from '@/elements/input';
-import { Label } from '@/elements/label';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/elements/tabs';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/elements/card';
-
-const TabsExample = () => (
-  <div className="flex w-full max-w-sm flex-col gap-6">
-    <Tabs defaultValue="account">
-      <TabsList>
-        <TabsTrigger value="account">Account</TabsTrigger>
-        <TabsTrigger value="password">Password</TabsTrigger>
-      </TabsList>
-      <TabsContent value="account">
-        <Card>
-          <CardHeader>
-            <CardTitle>Account</CardTitle>
-            <CardDescription>Make changes to your account here. Click save when you&apos;re done.</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-6">
-            <div className="grid gap-3">
-              <Label htmlFor="tabs-demo-name">Name</Label>
-              <Input id="tabs-demo-name" defaultValue="Pedro Duarte" />
-            </div>
-            <div className="grid gap-3">
-              <Label htmlFor="tabs-demo-username">Username</Label>
-              <Input id="tabs-demo-username" defaultValue="@peduarte" />
-            </div>
-          </CardContent>
-          <CardFooter>
-            <Button>Save changes</Button>
-          </CardFooter>
-        </Card>
-      </TabsContent>
-      <TabsContent value="password">
-        <Card>
-          <CardHeader>
-            <CardTitle>Password</CardTitle>
-            <CardDescription>Change your password here. After saving, you&apos;ll be logged out.</CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-6">
-            <div className="grid gap-3">
-              <Label htmlFor="tabs-demo-current">Current password</Label>
-              <Input id="tabs-demo-current" type="password" />
-            </div>
-            <div className="grid gap-3">
-              <Label htmlFor="tabs-demo-new">New password</Label>
-              <Input id="tabs-demo-new" type="password" />
-            </div>
-          </CardContent>
-          <CardFooter>
-            <Button>Save password</Button>
-          </CardFooter>
-        </Card>
-      </TabsContent>
-    </Tabs>
-  </div>
-);
+import { Button } from "@/elements/button";
+import { Input } from "@/elements/input";
+import { Label } from "@/elements/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/elements/tabs";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/elements/card";
 
 const meta = {
-  title: 'Elements/Tabs',
-  tags: ['autodocs'],
-  component: TabsExample,
+  title: "Elements/Tabs",
+  tags: ["autodocs"],
+  component: Tabs,
   parameters: {
     docs: {
       description: {
@@ -74,14 +28,73 @@ A reusable Tabs component.
 - @radix-ui/react-tabs
         `,
       },
+      source: {
+        type: "dynamic", // global, but explicit here for clarity
+      },
     },
   },
-} satisfies Meta<typeof TabsExample>;
+} satisfies Meta<typeof Tabs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Demo = {
-  render: () => <TabsExample />,
-} satisfies Story;
+// CSF2 named function export — Docs will show the full function body
+export function Demo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-6">
+      <Tabs defaultValue="account">
+        <TabsList>
+          <TabsTrigger value="account">Account</TabsTrigger>
+          <TabsTrigger value="password">Password</TabsTrigger>
+        </TabsList>
+        <TabsContent value="account">
+          <Card>
+            <CardHeader>
+              <CardTitle>Account</CardTitle>
+              <CardDescription>
+                Make changes to your account here. Click save when you&apos;re
+                done.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="tabs-demo-name">Name</Label>
+                <Input id="tabs-demo-name" defaultValue="Pedro Duarte" />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="tabs-demo-username">Username</Label>
+                <Input id="tabs-demo-username" defaultValue="@peduarte" />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button>Save changes</Button>
+            </CardFooter>
+          </Card>
+        </TabsContent>
+        <TabsContent value="password">
+          <Card>
+            <CardHeader>
+              <CardTitle>Password</CardTitle>
+              <CardDescription>
+                Change your password here. After saving, you&apos;ll be logged
+                out.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="tabs-demo-current">Current password</Label>
+                <Input id="tabs-demo-current" type="password" />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="tabs-demo-new">New password</Label>
+                <Input id="tabs-demo-new" type="password" />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button>Save password</Button>
+            </CardFooter>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/elements/tabs.stories.tsx
+++ b/src/elements/tabs.stories.tsx
@@ -1,21 +1,14 @@
-import type { Meta } from "@storybook/react-vite";
+import type { Meta } from '@storybook/react-vite';
 
-import { Button } from "@/elements/button";
-import { Input } from "@/elements/input";
-import { Label } from "@/elements/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/elements/tabs";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/elements/card";
+import { Button } from '@/elements/button';
+import { Input } from '@/elements/input';
+import { Label } from '@/elements/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/elements/tabs';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/elements/card';
 
 const meta = {
-  title: "Elements/Tabs",
-  tags: ["autodocs"],
+  title: 'Elements/Tabs',
+  tags: ['autodocs'],
   component: Tabs,
   parameters: {
     docs: {
@@ -29,7 +22,7 @@ A reusable Tabs component.
         `,
       },
       source: {
-        type: "dynamic", // global, but explicit here for clarity
+        type: 'dynamic', // global, but explicit here for clarity
       },
     },
   },
@@ -50,10 +43,7 @@ export function Demo() {
           <Card>
             <CardHeader>
               <CardTitle>Account</CardTitle>
-              <CardDescription>
-                Make changes to your account here. Click save when you&apos;re
-                done.
-              </CardDescription>
+              <CardDescription>Make changes to your account here. Click save when you&apos;re done.</CardDescription>
             </CardHeader>
             <CardContent className="grid gap-6">
               <div className="grid gap-3">
@@ -74,10 +64,7 @@ export function Demo() {
           <Card>
             <CardHeader>
               <CardTitle>Password</CardTitle>
-              <CardDescription>
-                Change your password here. After saving, you&apos;ll be logged
-                out.
-              </CardDescription>
+              <CardDescription>Change your password here. After saving, you&apos;ll be logged out.</CardDescription>
             </CardHeader>
             <CardContent className="grid gap-6">
               <div className="grid gap-3">


### PR DESCRIPTION


Fixes kubetail-org/kubetail#562

## Summary

This PR updates all Storybook stories in the `kubetail-ui` project to use named function exports (CSF2) instead of arrow functions or object-based render stories. The goal is to ensure that the "Show code" button in Storybook Docs displays the **full function source**, improving the clarity and usefulness of code examples for users and contributors.

## Changes

* Refactored stories to use named `function Demo()` exports instead of arrow functions or render objects.
* Removed per-story `StoryObj` and custom `parameters.docs.source` settings, relying on global dynamic source extraction.
* Updated Storybook global config to use `docs.source.type = 'dynamic'` for consistent and automatic code extraction.
* No changes to component logic; this is a documentation and developer experience improvement.

## Submitter checklist

* [x] Add the correct emoji to the PR title
* [x] Link the issue number, if any, to *Fixes kubetail-org/kubetail#562*
* [x] Add summary and explain changes in the PR description
* [x] Rebase branch to HEAD
* [ ] Squash changes into one signed, single commit

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)

