### PR TITLE
 ✨ Improve Button and Input component tests for accessibility and coverage

### DIFF
--- a/src/elements/__snapshots__/button.test.tsx.snap
+++ b/src/elements/__snapshots__/button.test.tsx.snap
@@ -9,6 +9,18 @@ exports[`Button > appends custom className 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Button > renders asChild properly 1`] = `
+<DocumentFragment>
+  <a
+    class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3"
+    data-slot="button"
+    href="/test"
+  >
+    Child Link
+  </a>
+</DocumentFragment>
+`;
+
 exports[`Button > renders contents properly 1`] = `
 <DocumentFragment>
   <button

--- a/src/elements/button.test.tsx
+++ b/src/elements/button.test.tsx
@@ -32,4 +32,46 @@ describe('Button', () => {
     const { asFragment } = render(<Button className="my-extra-class" />);
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('renders asChild properly', () => {
+    const { asFragment, getByText } = render(
+      <Button asChild>
+        <a href="/test">Child Link</a>
+      </Button>,
+    );
+    expect(getByText('Child Link').tagName).toBe('A');
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('handles onClick', () => {
+    const handleClick = vi.fn();
+    const { getByText } = render(<Button onClick={handleClick}>Click Me</Button>);
+    getByText('Click Me').click();
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('renders with aria-invalid', () => {
+    const { getByRole } = render(<Button aria-invalid>Invalid</Button>);
+    expect(getByRole('button')).toHaveAttribute('aria-invalid');
+  });
+
+  it('renders with an icon', () => {
+    const Icon = () => <svg data-testid="icon" />;
+    const { getByTestId } = render(
+      <Button>
+        <Icon />
+        Icon Btn
+      </Button>,
+    );
+    expect(getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders as link variant with href', () => {
+    const { getByText } = render(
+      <Button asChild variant="link">
+        <a href="/test">Link Btn</a>
+      </Button>,
+    );
+    expect(getByText('Link Btn')).toHaveAttribute('href', '/test');
+  });
 });

--- a/src/elements/input.test.tsx
+++ b/src/elements/input.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 import { Input } from './input';
 
@@ -6,5 +7,25 @@ describe('Input', () => {
   it('renders contents properly', () => {
     const { asFragment } = render(<Input placeholder="Enter text" />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('applies custom className', () => {
+    const { getByPlaceholderText } = render(<Input placeholder="Class test" className="custom-class" />);
+    expect(getByPlaceholderText('Class test')).toHaveClass('custom-class');
+  });
+
+  it('accepts and displays value', () => {
+    const { getByDisplayValue } = render(<Input value="Hello" onChange={() => {}} />);
+    expect(getByDisplayValue('Hello')).toBeInTheDocument();
+  });
+
+  it('renders as disabled', () => {
+    const { getByPlaceholderText } = render(<Input placeholder="Disabled test" disabled />);
+    expect(getByPlaceholderText('Disabled test')).toBeDisabled();
+  });
+
+  it('sets aria-invalid when invalid', () => {
+    const { getByPlaceholderText } = render(<Input placeholder="Invalid test" aria-invalid />);
+    expect(getByPlaceholderText('Invalid test')).toHaveAttribute('aria-invalid');
   });
 });


### PR DESCRIPTION
<!-- 
Put one of these emojis in your title to indicate the type of PR:
- 🎣 Bug fix
- 🐋 New feature
- 📜 Documentation
- ✨ General improvement
-->

Fixes kubetail-org/kubetail#561

## Summary

Improves test coverage for the `Button` and `Input` components by adding and refining test cases to ensure accessibility, proper rendering, and event handling.

## Changes

* Added and updated tests for `Button` component, including:

  * Rendering with `asChild` (anchor tag)
  * Click event handling
  * Accessibility attributes (`aria-invalid`)
  * Rendering with icon and as link variant
* Enhanced `Input` component tests for:

  * Custom `className`
  * Controlled value
  * Disabled state
  * Accessibility attributes

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [ ] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)






