### PR TITLE
🐋 Add ability to set container class name to Table component

### DIFF
--- a/src/elements/table.test.tsx
+++ b/src/elements/table.test.tsx
@@ -39,6 +39,21 @@ describe('Table Components', () => {
       expect(table).toHaveClass('custom-table-class');
     });
 
+    it('applies custom containerClassName properly', () => {
+      const { container } = render(
+        <Table containerClassName="custom-table-class">
+          <tbody>
+            <tr>
+              <td>Cell content</td>
+            </tr>
+          </tbody>
+        </Table>,
+      );
+
+      const table = container.querySelector('[data-slot="table-container"]');
+      expect(table).toHaveClass('custom-table-class');
+    });
+
     it('passes through additional props', () => {
       const { container } = render(
         <Table data-testid="test-table" id="my-table">

--- a/src/elements/table.tsx
+++ b/src/elements/table.tsx
@@ -2,9 +2,13 @@
 
 import { cn } from '@/lib/utils';
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+interface TableProps extends React.ComponentProps<'table'> {
+  containerClassName?: string;
+}
+
+function Table({ className, containerClassName, ...props }: TableProps) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+    <div data-slot="table-container" className={cn('relative w-full overflow-x-auto', containerClassName)}>
       <table data-slot="table" className={cn('w-full caption-bottom text-sm', className)} {...props} />
     </div>
   );
@@ -71,3 +75,4 @@ function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) 
 }
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export type { TableProps };


### PR DESCRIPTION
## Summary

Adds support for optional `containerClassName` to `Table` component which allows user to set custom class name on table container div.

## Submitter checklist

- [x] Add the correct emoji to the PR title
- [x] Link the issue number, if any, to *Fixes #*
- [x] Add summary and explain changes in the PR description
- [ ] Rebase branch to HEAD
- [x] Squash changes into one signed, single commit [^1]

[^1]: See suggested [commit format](https://github.com/kubetail-org/.github/blob/main/pull-request-commit-format.md)
