### PR TITLE
🐋 Add alert component with stories and tests

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -49,6 +49,7 @@ const preview: Preview = {
           'Elements',
           [
             'Overview',
+            'Alert',
             'Avatar',
             'Button',
             'Calendar',

--- a/src/elements/alert.stories.tsx
+++ b/src/elements/alert.stories.tsx
@@ -1,0 +1,91 @@
+import { CircleAlert, Info, Terminal, TriangleAlert } from 'lucide-react';
+import type { Meta } from '@storybook/react-vite';
+
+import { Alert, AlertTitle, AlertDescription, AlertAction } from '@/elements/alert';
+import { Button } from '@/elements/button';
+
+const meta = {
+  title: 'Elements/Alert',
+  tags: ['autodocs'],
+  component: Alert,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Displays a callout for important information, warnings, or errors.',
+      },
+    },
+  },
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+
+export function Default() {
+  return (
+    <Alert>
+      <Terminal />
+      <AlertTitle>Heads up!</AlertTitle>
+      <AlertDescription>You can add components to your app using the CLI.</AlertDescription>
+    </Alert>
+  );
+}
+
+export function Destructive() {
+  return (
+    <Alert variant="destructive">
+      <CircleAlert />
+      <AlertTitle>Error</AlertTitle>
+      <AlertDescription>Your session has expired. Please log in again.</AlertDescription>
+    </Alert>
+  );
+}
+
+export function WithAction() {
+  return (
+    <Alert>
+      <Info />
+      <AlertTitle>Update available</AlertTitle>
+      <AlertDescription>A new version is available. Update now to get the latest features.</AlertDescription>
+      <AlertAction>
+        <Button variant="outline" size="sm">
+          Update
+        </Button>
+      </AlertAction>
+    </Alert>
+  );
+}
+
+export function TitleOnly() {
+  return (
+    <Alert>
+      <TriangleAlert />
+      <AlertTitle>Warning: This action cannot be undone.</AlertTitle>
+    </Alert>
+  );
+}
+
+export function Demo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Alert>
+        <Terminal />
+        <AlertTitle>Heads up!</AlertTitle>
+        <AlertDescription>You can add components to your app using the CLI.</AlertDescription>
+      </Alert>
+      <Alert variant="destructive">
+        <CircleAlert />
+        <AlertTitle>Error</AlertTitle>
+        <AlertDescription>Your session has expired. Please log in again.</AlertDescription>
+      </Alert>
+      <Alert>
+        <Info />
+        <AlertTitle>Update available</AlertTitle>
+        <AlertDescription>A new version is available. Update now to get the latest features.</AlertDescription>
+        <AlertAction>
+          <Button variant="outline" size="sm">
+            Update
+          </Button>
+        </AlertAction>
+      </Alert>
+    </div>
+  );
+}

--- a/src/elements/alert.test.tsx
+++ b/src/elements/alert.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react';
+import { Alert, AlertTitle, AlertDescription, AlertAction } from './alert';
+
+describe('Alert', () => {
+  it('renders with children', () => {
+    const { getByRole } = render(<Alert>Alert content</Alert>);
+    const alert = getByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Alert content');
+  });
+
+  it('applies custom className', () => {
+    const { getByRole } = render(<Alert className="custom-class" />);
+    expect(getByRole('alert')).toHaveClass('custom-class');
+  });
+
+  it('has data-slot attribute', () => {
+    const { getByRole } = render(<Alert />);
+    expect(getByRole('alert')).toHaveAttribute('data-slot', 'alert');
+  });
+
+  it('renders default variant', () => {
+    const { getByRole } = render(<Alert />);
+    expect(getByRole('alert')).toHaveClass('bg-card');
+  });
+
+  it('renders destructive variant', () => {
+    const { getByRole } = render(<Alert variant="destructive" />);
+    expect(getByRole('alert')).toHaveClass('text-destructive');
+  });
+});
+
+describe.each([
+  ['AlertTitle', AlertTitle, 'alert-title'],
+  ['AlertDescription', AlertDescription, 'alert-description'],
+  ['AlertAction', AlertAction, 'alert-action'],
+] as const)('%s', (_, Component, slot) => {
+  it('renders with children', () => {
+    const { getByTestId } = render(<Component data-testid="el">Content</Component>);
+    expect(getByTestId('el')).toBeInTheDocument();
+    expect(getByTestId('el')).toHaveTextContent('Content');
+  });
+
+  it('has data-slot attribute', () => {
+    const { getByTestId } = render(<Component data-testid="el">Content</Component>);
+    expect(getByTestId('el')).toHaveAttribute('data-slot', slot);
+  });
+
+  it('applies custom className', () => {
+    const { getByTestId } = render(
+      <Component data-testid="el" className="custom-class">
+        Content
+      </Component>,
+    );
+    expect(getByTestId('el')).toHaveClass('custom-class');
+  });
+});
+
+describe('Alert composition', () => {
+  it('renders a full alert with all sub-components', () => {
+    const { getByRole, getByTestId } = render(
+      <Alert>
+        <AlertTitle data-testid="title">Warning</AlertTitle>
+        <AlertDescription data-testid="desc">Something happened.</AlertDescription>
+        <AlertAction data-testid="action">
+          <button type="button">Dismiss</button>
+        </AlertAction>
+      </Alert>,
+    );
+    expect(getByRole('alert')).toBeInTheDocument();
+    expect(getByTestId('title')).toHaveTextContent('Warning');
+    expect(getByTestId('desc')).toHaveTextContent('Something happened.');
+    expect(getByTestId('action')).toHaveTextContent('Dismiss');
+  });
+});

--- a/src/elements/alert.tsx
+++ b/src/elements/alert.tsx
@@ -1,0 +1,55 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Alert({ className, variant, ...props }: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        'cn-font-heading font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        'text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="alert-action" className={cn('absolute top-2 right-2', className)} {...props} />;
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };


### PR DESCRIPTION
## Summary

Add a new Alert component to the UI library with support for default and destructive variants, including Storybook stories and unit tests.

## Key Changes

- Add `Alert`, `AlertTitle`, `AlertDescription`, and `AlertAction` components using `cva` for variant-based styling
- Add Storybook stories demonstrating default, destructive, with-action, title-only, and combined usage
- Add unit tests covering rendering, variants, data-slot attributes, custom classNames, and composition
- Add Alert to the Storybook sidebar in alphabetical order

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused