### PR TITLE
✨ Adjust sidebar spacing and trigger hover styles

### DIFF
--- a/src/elements/__snapshots__/sidebar.test.tsx.snap
+++ b/src/elements/__snapshots__/sidebar.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Sidebar > Basic rendering > renders properly 1`] = `
             Header
           </div>
           <div
-            class="no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden"
+            class="no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden"
             data-sidebar="content"
             data-slot="sidebar-content"
           >
@@ -68,7 +68,7 @@ exports[`Sidebar > Basic rendering > renders properly 1`] = `
     </div>
     <main>
       <button
-        class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg"
+        class="group/button inline-flex shrink-0 items-center justify-center border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50 size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
         data-sidebar="trigger"
         data-slot="sidebar-trigger"
         tabindex="0"

--- a/src/elements/sidebar.tsx
+++ b/src/elements/sidebar.tsx
@@ -242,7 +242,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
-      className={cn(className)}
+      className={cn('hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground', className)}
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
@@ -344,7 +344,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        'no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
         className,
       )}
       {...props}
@@ -427,7 +427,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn('flex w-full min-w-0 flex-col gap-0', className)}
+      className={cn('flex w-full min-w-0 flex-col gap-1', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Small visual polish for the sidebar component: restores hover feedback on the collapse trigger and introduces consistent vertical rhythm between sidebar sections and menu items.

## Key Changes

- Add `hover:bg-sidebar-accent/50` and `hover:text-sidebar-accent-foreground` to `SidebarTrigger` so the toggle button has visible hover feedback.
- Bump `SidebarContent` gap from `0` to `2` for clearer separation between groups.
- Bump `SidebarMenu` gap from `0` to `1` so menu items breathe.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused