### PR TITLE
✨ Adopt theme colors in spinner and drop chrome scale

### DIFF
--- a/src/elements/__snapshots__/spinner.test.tsx.snap
+++ b/src/elements/__snapshots__/spinner.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Spinner > appends custom className 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-8 h-8 my-custom-class"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-8 h-8 my-custom-class"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
@@ -37,7 +37,7 @@ exports[`Spinner > renders all size variants properly 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-4 h-4"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-4 h-4"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
@@ -67,7 +67,7 @@ exports[`Spinner > renders all size variants properly 2`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-6 h-6"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-6 h-6"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
@@ -97,7 +97,7 @@ exports[`Spinner > renders all size variants properly 3`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-8 h-8"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-8 h-8"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
@@ -127,7 +127,7 @@ exports[`Spinner > renders all size variants properly 4`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-10 h-10"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-10 h-10"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"
@@ -157,7 +157,7 @@ exports[`Spinner > renders with default props 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="animate-spin mr-2 text-chrome-200 fill-chrome-500 w-8 h-8"
+      class="animate-spin mr-2 text-muted-foreground/25 fill-primary w-8 h-8"
       fill="none"
       viewBox="0 0 100 101"
       xmlns="http://www.w3.org/2000/svg"

--- a/src/elements/spinner.test.tsx
+++ b/src/elements/spinner.test.tsx
@@ -58,8 +58,6 @@ describe('Spinner', () => {
 
     expect(svg).toHaveClass('animate-spin');
     expect(svg).toHaveClass('mr-2');
-    expect(svg).toHaveClass('text-chrome-200');
-    expect(svg).toHaveClass('fill-chrome-500');
   });
 
   it('merges custom className with base classes', () => {

--- a/src/elements/spinner.tsx
+++ b/src/elements/spinner.tsx
@@ -14,7 +14,7 @@
 
 import { cn } from '@/lib/utils';
 
-const baseCN = 'animate-spin mr-2 text-chrome-200 fill-chrome-500';
+const baseCN = 'animate-spin mr-2 text-muted-foreground/25 fill-primary';
 
 type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg';
 


### PR DESCRIPTION
## Summary

Follow-up to the oklch palette migration (#117), which removed the
`chrome` color scale. The spinner still referenced `text-chrome-200`
and `fill-chrome-500`, leaving it visually inconsistent with the rest
of the restyled components. This aligns it with the shared theme
tokens.

## Key Changes

- Replace `text-chrome-200`/`fill-chrome-500` with
  `text-muted-foreground/25`/`fill-primary` in the spinner base classes
- Drop the now-irrelevant chrome class assertions from the spinner test
- Update the spinner snapshot to match

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused