### PR TITLE
🎣 Darken sidebar background and border colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -27,13 +27,13 @@
   --chart-3: oklch(0.4882 0.2172 264.3763);
   --chart-4: oklch(0.4244 0.1809 265.6377);
   --chart-5: oklch(0.3791 0.1378 265.5222);
-  --sidebar: oklch(0.9846 0.0017 247.8389);
+  --sidebar: oklch(0.9600 0.0017 247.8389);                      /* custom */
   --sidebar-foreground: oklch(0.3211 0 0);
   --sidebar-primary: oklch(0.6231 0.1880 259.8145);
   --sidebar-primary-foreground: oklch(1.0000 0 0);
   --sidebar-accent: oklch(0.9514 0.0250 236.8242);
   --sidebar-accent-foreground: oklch(0.3791 0.1378 265.5222);
-  --sidebar-border: oklch(0.9276 0.0058 264.5313);
+  --sidebar-border: oklch(0.8976 0.0058 264.5313);              /* custom */
   --sidebar-ring: oklch(0.6231 0.1880 259.8145);
   --radius: 0.375rem;
 }


### PR DESCRIPTION
## Summary

Darkens the sidebar background and border colors in the light theme to improve visual contrast and make the sidebar more distinct from the main content area.

## Key Changes

- Reduce `--sidebar` lightness from `0.9846` to `0.9600`
- Reduce `--sidebar-border` lightness from `0.9276` to `0.8976`

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused