### PR TITLE
🎣 Increase default border radius to 0.5rem

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,9 +33,9 @@
   --sidebar-primary-foreground: oklch(1.0000 0 0);
   --sidebar-accent: oklch(0.9514 0.0250 236.8242);
   --sidebar-accent-foreground: oklch(0.3791 0.1378 265.5222);
-  --sidebar-border: oklch(0.8976 0.0058 264.5313);              /* custom */
+  --sidebar-border: oklch(0.8976 0.0058 264.5313);               /* custom */
   --sidebar-ring: oklch(0.6231 0.1880 259.8145);
-  --radius: 0.375rem;
+  --radius: 0.5rem;                                                /* custom */
 }
 
 .dark {


### PR DESCRIPTION
## Summary

Bumps the global `--radius` CSS custom property from `0.375rem` to `0.5rem` to give UI elements slightly more rounded corners.

## Key Changes

- Updated `--radius` in `src/index.css` from `0.375rem` to `0.5rem` and marked it as a custom override

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use conventional commit format
- [x] Changes are minimal and focused