### PR TITLE
🎣 Sync sidebar-primary color with primary

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
   --card-foreground: oklch(0.3211 0 0);
   --popover: oklch(1.0000 0 0);
   --popover-foreground: oklch(0.3211 0 0);
-  --primary: oklch(0.563 0.194 262.62);
+  --primary: oklch(0.563 0.194 262.62);                          /* custom */
   --primary-foreground: oklch(1.0000 0 0);
   --secondary: oklch(0.9670 0.0029 264.5419);
   --secondary-foreground: oklch(0.4461 0.0263 256.8018);
@@ -29,7 +29,7 @@
   --chart-5: oklch(0.3791 0.1378 265.5222);
   --sidebar: oklch(0.9600 0.0017 247.8389);                      /* custom */
   --sidebar-foreground: oklch(0.3211 0 0);
-  --sidebar-primary: oklch(0.6231 0.1880 259.8145);
+  --sidebar-primary: oklch(0.563 0.194 262.62);                  /* custom */
   --sidebar-primary-foreground: oklch(1.0000 0 0);
   --sidebar-accent: var(--color-blue-200);                         /* custom */
   --sidebar-accent-foreground: oklch(0.3791 0.1378 265.5222);


### PR DESCRIPTION
## Summary

Aligns `--sidebar-primary` with `--primary` so the sidebar uses a consistent brand color in light mode. Also marks `--primary` with a `/* custom */` comment for consistency with other custom tokens.

## Key Changes

- Changed `--sidebar-primary` from `oklch(0.6231 0.1880 259.8145)` to `oklch(0.563 0.194 262.62)` to match `--primary`
- Added `/* custom */` comment to `--primary` to match the annotation style of other overridden tokens

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused