### PR TITLE
🎣 Strip leading "v" from publish version to fix provenance failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
 
       - run: pnpm build
 
-      - run: /bin/bash set-version.sh v${{ needs.config.outputs.version }}
+      - run: /bin/bash set-version.sh ${{ needs.config.outputs.version }}
 
       - name: Publish
         if: ${{ needs.config.outputs.dry_run == 'false' }}

--- a/set-version.sh
+++ b/set-version.sh
@@ -6,8 +6,9 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-# Assign the new version number from command line arguments
-NEW_VERSION=$1
+# Assign the new version number from command line arguments, stripping any
+# leading "v" so the version stays valid semver (e.g. "v3.0.0" -> "3.0.0")
+NEW_VERSION=${1#v}
 
 # Path to the local package.json file
 PACKAGE_JSON="./package.json"


### PR DESCRIPTION
## Summary

The `publish` workflow has been failing at the npm publish step with a
sigstore provenance error (E422 — "Failed to validate the provenance
subject against the package name, version and tarball integrity").

The root cause is a long-standing quirk that only became fatal recently.
The workflow passed the tag's `v`-prefixed version into `set-version.sh`,
which wrote an invalid semver (e.g. `v3.0.0`) into `package.json`. npm
normalized this for plain token-based publishes, so it went unnoticed.
After the toolchain bump in #108, the newer pnpm now generates a sigstore
provenance attestation whose subject uses the literal `package.json`
version (`v3.0.0`), which no longer matches the normalized published
coordinates and tarball (`3.0.0`) — so the registry rejects the bundle.

## Key Changes

- Drop the `v` prefix when invoking `set-version.sh` in `publish.yml` so
  the version stays valid semver.
- Strip a leading `v` defensively in `set-version.sh` (`NEW_VERSION=${1#v}`)
  so a stray prefix can't corrupt the version again.

## Checklist

- [x] Add the correct emoji to the PR title
- [ ] Related issue linked above, if any
- [x] Commit messages use [conventional commit](https://www.conventionalcommits.org) format
- [x] Changes are minimal and focused